### PR TITLE
"Soft fullscreen" on launch - maximize canvas in browser client area

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -192,7 +192,6 @@ float get_daylight() {
 int get_scale_factor() {
     int window_width, window_height;
     int buffer_width, buffer_height;
-    // TODO: how is this different or is it different than emscripten_get_canvas_size()?
     glfwGetWindowSize(g->window, &window_width, &window_height);
     glfwGetFramebufferSize(g->window, &buffer_width, &buffer_height);
     int result = buffer_width / window_width;
@@ -2617,8 +2616,9 @@ EM_BOOL on_canvassize_changed(int eventType, const void *reserved, void *userDat
   double cssW, cssH;
   emscripten_get_element_css_size(0, &cssW, &cssH);
   printf("Canvas resized: WebGL RTT size: %dx%d, canvas CSS size: %02gx%02g\n", w, h, cssW, cssH);
+
+  glfwSetWindowSize(g->window, w, h);
   return 0;
-  // TODO: resize drawing area or what?
 }
 #endif
 


### PR DESCRIPTION
The game area (= html5 canvas) should be maximized into the browser client space, after emscripten finishes initializing (payload downloaded and execution began), probably in main() after glClearColor().

Note this is distinct from true fullscreen, which expands beyond the browser onto the whole window of the user: https://github.com/satoshinm/NetCraft/issues/9 - rather, what emscripten calls "soft fullscreen" is more like what the user expects with a native app, where the graphics full the entire window, no extra widgets like this (based on the default shell file):

![screen shot 2017-04-04 at 11 17 15 pm](https://cloud.githubusercontent.com/assets/26856618/24692239/e65413b4-198c-11e7-91b4-c1e2ba903b14.png)
