### PR TITLE
Fullscreen web: F11 to toggle fullscreen/fullwindow not only natively but also on web platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ add_definitions(-std=c99 -O3)
 
 if (EMSCRIPTEN)
     # Emscripten default is GLFW 2.x but we use GLFW 3.x, also include data files
-    set_target_properties(craft PROPERTIES LINK_FLAGS "-s EXPORTED_FUNCTIONS=\"['_main', '_browser_resize_callback']\" -O2 -s USE_GLFW=3 --pre-js ../src/pre.js --shell-file ../src/shell.html --embed-file ../shaders/ -s TOTAL_MEMORY=33554432 --embed-file ../textures/")
+    set_target_properties(craft PROPERTIES LINK_FLAGS "-O2 -s USE_GLFW=3 --pre-js ../src/pre.js --shell-file ../src/shell.html --embed-file ../shaders/ -s TOTAL_MEMORY=33554432 --embed-file ../textures/")
 endif ()
 
 if (NOT EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ add_definitions(-std=c99 -O3)
 
 if (EMSCRIPTEN)
     # Emscripten default is GLFW 2.x but we use GLFW 3.x, also include data files
-    set_target_properties(craft PROPERTIES LINK_FLAGS "-O2 -s USE_GLFW=3 --pre-js ../src/pre.js --shell-file ../src/shell.html --embed-file ../shaders/ -s TOTAL_MEMORY=33554432 --embed-file ../textures/")
+    set_target_properties(craft PROPERTIES LINK_FLAGS "-s EXPORTED_FUNCTIONS=\"['_main', '_browser_resize_callback']\" -O2 -s USE_GLFW=3 --pre-js ../src/pre.js --shell-file ../src/shell.html --embed-file ../shaders/ -s TOTAL_MEMORY=33554432 --embed-file ../textures/")
 endif ()
 
 if (NOT EMSCRIPTEN)

--- a/src/main.c
+++ b/src/main.c
@@ -2422,8 +2422,6 @@ void on_mouse_button(GLFWwindow *window, int button, int action, int mods) {
 #ifdef __EMSCRIPTEN__
 EM_BOOL on_canvassize_changed(int eventType, const void *reserved, void *userData) {
     // Resize window to match canvas size (as browser is resized).
-    // Note: would've likde to use canvasResizedCallback, but it is
-    // only available in https://kripken.github.io/emscripten-site/docs/api_reference/html5.h.html#c.EmscriptenFullscreenStrategy
     int w = 0;
     int h = 0;
     int isFullscreen = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -3053,6 +3053,25 @@ void main_shutdown() {
 
 void one_iter() {
     glfwSwapInterval(VSYNC);
+
+#ifdef __EMSCRIPTEN__
+    // Resize window to match canvas size (as browser is resized).
+    // TODO: can this be switched to events? would like to use canvasResizedCallback, but it is
+    // only available in https://kripken.github.io/emscripten-site/docs/api_reference/html5.h.html#c.EmscriptenFullscreenStrategy
+    int canvas_width = 0;
+    int canvas_height = 0;
+    int isFullscreen = 0;
+    static int last_canvas_width = 0;
+    static int last_canvas_height = 0;
+    emscripten_get_canvas_size(&canvas_width, &canvas_height, &isFullscreen);
+    if (!isFullscreen && (canvas_width != last_canvas_width || canvas_height != last_canvas_height)) {
+        printf("canvas size changed: %d x %d -> %d x %d\n", last_canvas_width, last_canvas_height, canvas_width, canvas_height);
+        glfwSetWindowSize(g->window, canvas_width, canvas_height);
+    }
+    last_canvas_width = canvas_width;
+    last_canvas_height = canvas_height;
+#endif
+
             // WINDOW SIZE AND SCALE //
             g->scale = get_scale_factor(g->window);
             glfwGetFramebufferSize(g->window, &g->width, &g->height);

--- a/src/main.c
+++ b/src/main.c
@@ -2448,6 +2448,21 @@ EM_BOOL on_canvassize_changed(int eventType, const void *reserved, void *userDat
     return EM_FALSE;
 }
 
+// Emscripten's "soft fullscreen" = maximizes the canvas in the browser client area, wanted to toggle soft/hard fullscreen
+void maximize_canvas() {
+    EmscriptenFullscreenStrategy strategy = {
+        .scaleMode = EMSCRIPTEN_FULLSCREEN_SCALE_STRETCH,
+        .canvasResolutionScaleMode = EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_STDDEF,
+        .filteringMode = EMSCRIPTEN_FULLSCREEN_FILTERING_DEFAULT, // or EMSCRIPTEN_FULLSCREEN_FILTERING_NEAREST
+        .canvasResizedCallback = on_canvassize_changed,
+        .canvasResizedCallbackUserData = NULL
+    };
+
+    EMSCRIPTEN_RESULT ret = emscripten_enter_soft_fullscreen("#canvas", &strategy);
+
+    on_canvassize_changed(0, NULL, NULL);
+}
+
 void on_window_size(GLFWwindow* window, int width, int height) {
     static int inFullscreen = 0;
     static int wasFullscreen = 0;
@@ -2463,22 +2478,8 @@ void on_window_size(GLFWwindow* window, int width, int height) {
 
     if (wasFullscreen && !isInFullscreen) {
         wasFullscreen = isInFullscreen;
+        maximize_canvas();
     }
-}
-
-// Emscripten's "soft fullscreen" = maximizes the canvas in the browser client area, wanted to toggle soft/hard fullscreen
-void maximize_canvas() {
-    EmscriptenFullscreenStrategy strategy = {
-        .scaleMode = EMSCRIPTEN_FULLSCREEN_SCALE_STRETCH,
-        .canvasResolutionScaleMode = EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_STDDEF,
-        .filteringMode = EMSCRIPTEN_FULLSCREEN_FILTERING_DEFAULT, // or EMSCRIPTEN_FULLSCREEN_FILTERING_NEAREST
-        .canvasResizedCallback = on_canvassize_changed,
-        .canvasResizedCallbackUserData = NULL
-    };
-
-    EMSCRIPTEN_RESULT ret = emscripten_enter_soft_fullscreen("#canvas", &strategy);
-
-    on_canvassize_changed(0, NULL, NULL);
 }
 
 EM_BOOL fullscreen_change_callback(int eventType, const EmscriptenFullscreenChangeEvent *event, void *userData) {

--- a/src/main.c
+++ b/src/main.c
@@ -2431,9 +2431,21 @@ EM_BOOL on_canvassize_changed(int eventType, const void *reserved, void *userDat
 
     double cssW, cssH;
     emscripten_get_element_css_size(0, &cssW, &cssH);
-    printf("Canvas resized: WebGL RTT size: %dx%d, canvas CSS size: %02gx%02g\n", w, h, cssW, cssH);
 
     glfwSetWindowSize(g->window, w, h);
+
+    int fb_w, fb_h;
+    glfwGetFramebufferSize(g->window, &fb_w, &fb_h);
+
+    // http://www.glfw.org/docs/latest/window.html#window_size
+    // "Note
+    // Do not pass the window size to glViewport or other pixel-based OpenGL calls.
+    // The window size is in screen coordinates, not pixels. Use the framebuffer
+    // size, which is in pixels, for pixel-based calls."
+    int w_w, w_h;
+    glfwGetWindowSize(g->window, &w_w, &w_h);
+    printf("Canvas resized: WebGL RTT size: %dx%d, framebuffer: %dx%d, window: %dx%d, canvas CSS size: %02gx%02g\n", w, h, fb_w, fb_h, w_w, w_h, cssW, cssH);
+
 
     return EM_FALSE;
 }


### PR DESCRIPTION
To fix https://github.com/satoshinm/NetCraft/issues/49 Soft fullscreen removes <body> element so document.body.style causes null deref