### PR TITLE
Add emscripten build targets for Linux on CircleCI 2.0. Closes GH-37

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,22 @@ jobs:
         steps:
             - checkout
             - run: 
-                name: Setup
+                name: Setup dependencies
                 command: |
                   apt-get update
                   apt-get install -y cmake libglew-dev xorg-dev libcurl4-openssl-dev
                   apt-get install -y libglfw-dev
                   mkdir native-build
-                  cd native-build && cmake ..
+                  (cd native-build && cmake ..)
+                  
+                  apt-get install -y emscripten
+                  mkdir release-build-js
+                  (cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
             - run:
-                name: Native Build
+                name: native-build
                 command: cd native-build && make
+            - run:
+                name: release-build-js
+                command: cd release-build-js && make
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,16 @@ jobs:
         working_directory: ~/NetCraft
         steps:
             - checkout
-            - run: apt-get update
-            - run: apt-get install -y cmake libglew-dev xorg-dev libcurl4-openssl-dev
-            - run: apt-get install -y libglfw-dev
-            - run: mkdir native-build
-            - run: cd native-build && cmake ..
-            - run: cd native-build && make
+            - run: 
+                name: Setup
+                command: |
+                  apt-get update
+                  apt-get install -y cmake libglew-dev xorg-dev libcurl4-openssl-dev
+                  apt-get install -y libglfw-dev
+                  mkdir native-build
+                  cd native-build && cmake ..
+            - run:
+                name: Native Build
+                command: cd native-build && make
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: buildpack-deps:zesty
+            - image: buildpack-deps:xenial
         environment:
             EMSCRIPTEN: /usr/share/emscripten
         working_directory: ~/NetCraft

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ jobs:
                   apt install -y nodejs
                   apt install -y default-jre
                   wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz
+                  ls -l emsdk-portable.tar.gz
+                  ls
                   tar xf emsdk-portable.tar.gz
                   ~/emsdk-portable/emsdk update
                   ~/emsdk-portable/emsdk install latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@ jobs:
     build:
         docker:
             - image: buildpack-deps:xenial
-        environment:
-            EMSCRIPTEN: /usr/share/emscripten
         working_directory: ~/NetCraft
         steps:
             - checkout
@@ -16,8 +14,16 @@ jobs:
                   apt install -y libglfw3-dev
                   mkdir native-build
                   (cd native-build && cmake ..)
-                  
-                  apt install -y emscripten
+                  # http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#platform-notes-installation-instructions-portable-sdk
+                  apt install -y python2.7
+                  apt install -y nodejs
+                  apt install -y default-jre
+                  wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz
+                  tar xf emsdk-portable.tar.gz
+                  ~/emsdk-portable/emsdk update
+                  ~/emsdk-portable/emsdk install latest
+                  ~/emsdk-portable/emsdk activate latest
+                  source ~/emsdk-portable/emsdk_env.sh
                   mkdir build
                   (cd build && cmake -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
             - run:
@@ -25,6 +31,6 @@ jobs:
                 command: cd native-build && make
             - run:
                 name: build (web)
-                command: cd build && make
+                command: cd build && source ~/emsdk-portable/emsdk_env.sh && make
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
         steps:
             - checkout
             - run: apt-get update
-            - run: apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
-            - run: apt-get install libglfw-dev
+            - run: apt-get install -y cmake libglew-dev xorg-dev libcurl4-openssl-dev
+            - run: apt-get install -y libglfw-dev
             - run: mkdir native-build
             - run: cd native-build && cmake ..
             - run: cd native-build && make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,13 @@ jobs:
                   (cd native-build && cmake ..)
                   
                   apt install -y emscripten
-                  mkdir release-build-js
-                  (cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
+                  mkdir build
+                  (cd build && cmake -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
             - run:
                 name: native-build
                 command: cd native-build && make
             - run:
-                name: release-build-js
-                command: cd release-build-js && make
+                name: build (web)
+                command: cd build && make
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2
 jobs:
     build:
         docker:
-            - image: buildpack-deps:xenial-scm
+            - image: buildpack-deps:xenial
         environment:
             EMSCRIPTEN: /usr/share/emscripten
         working_directory: ~/NetCraft
         steps:
             - checkout
-            - run: sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
-            - run: sudo apt-get install libglfw-dev
+            - run: apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
+            - run: apt-get install libglfw-dev
             - run: mkdir native-build
             - run: cd native-build && cmake ..
             - run: cd native-build && make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,7 @@ jobs:
                   apt install -y nodejs
                   apt install -y default-jre
                   wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz
-                  ls -l emsdk-portable.tar.gz
-                  ls
-                  tar xf emsdk-portable.tar.gz
+                  tar xf emsdk-portable.tar.gz -C ~
                   ~/emsdk-portable/emsdk update
                   ~/emsdk-portable/emsdk install latest
                   ~/emsdk-portable/emsdk activate latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,14 @@ jobs:
                   source ~/emsdk-portable/emsdk_env.sh
                   mkdir release-build-js
                   (cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
+                  mkdir wasm-build
+                  (cd wasm-build && cmake -DWASM=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
             - run:
                 name: native-build
                 command: cd native-build && make
             - run:
                 name: release-build-js
                 command: cd release-build-js && source ~/emsdk-portable/emsdk_env.sh && make
-
-
+            - run:
+                name: wasm-build
+                command: cd wasm-build && source ~/emsdk-portable/emsdk_env.sh && make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
                 command: |
                   apt update
                   apt install -y cmake libglew-dev xorg-dev libcurl4-openssl-dev
-                  apt install -y libglfw-dev
+                  apt install -y libglfw3-dev
                   mkdir native-build
                   (cd native-build && cmake ..)
                   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: buildpack-deps:xenial
+            - image: buildpack-deps:xenial-scm
         environment:
             EMSCRIPTEN: /usr/share/emscripten
         working_directory: ~/NetCraft

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
             - run: 
                 name: Setup dependencies
                 command: |
-                  apt-get update
-                  apt-get install -y cmake libglew-dev xorg-dev libcurl4-openssl-dev
-                  apt-get install -y libglfw-dev
+                  apt update
+                  apt install -y cmake libglew-dev xorg-dev libcurl4-openssl-dev
+                  apt install -y libglfw-dev
                   mkdir native-build
                   (cd native-build && cmake ..)
                   
-                  apt-get install -y emscripten
+                  apt install -y emscripten
                   mkdir release-build-js
                   (cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: buildpack-deps:trusty
+            - image: buildpack-deps:zesty
         environment:
             EMSCRIPTEN: /usr/share/emscripten
         working_directory: ~/NetCraft

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+    build:
+        docker:
+            - image: buildpack-deps:trusty
+        environment:
+            EMSCRIPTEN: /usr/share/emscripten
+        working_directory: ~/NetCraft
+        steps:
+            - checkout
+            - run: sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
+            - run: sudo apt-get install libglfw-dev
+            - run: mkdir native-build
+            - run: cd native-build && cmake ..
+            - run: cd native-build && make
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,13 @@ jobs:
                   ~/emsdk-portable/emsdk install latest
                   ~/emsdk-portable/emsdk activate latest
                   source ~/emsdk-portable/emsdk_env.sh
-                  mkdir build
-                  (cd build && cmake -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
+                  mkdir release-build-js
+                  (cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
             - run:
                 name: native-build
                 command: cd native-build && make
             - run:
-                name: build (web)
-                command: cd build && source ~/emsdk-portable/emsdk_env.sh && make
+                name: release-build-js
+                command: cd release-build-js && source ~/emsdk-portable/emsdk_env.sh && make
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
         working_directory: ~/NetCraft
         steps:
             - checkout
+            - run: apt-get update
             - run: apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
             - run: apt-get install libglfw-dev
             - run: mkdir native-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,21 +69,20 @@ else ()
     set(CURL_LIBRARIES "")
 endif ()
 
-find_package(OpenGL REQUIRED)
-
 if(APPLE OR EMSCRIPTEN)
     target_link_libraries(craft glfw
-        ${OPENGL_gl_LIBRARY}
         ${GLFW_LIBRARIES} ${CURL_LIBRARIES})
 endif()
 
 if(UNIX AND NOT EMSCRIPTEN)
+    find_package(OpenGL REQUIRED)
     target_link_libraries(craft dl glfw
         ${OPENGL_gl_LIBRARY}
         ${GLFW_LIBRARIES} ${CURL_LIBRARIES})
 endif()
 
 if(MINGW OR MSVC)
+    find_package(OpenGL REQUIRED)
     target_link_libraries(craft ws2_32.lib glfw
         ${OPENGL_gl_LIBRARY}
         ${GLFW_LIBRARIES} ${CURL_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ the installation:
 
     brew install cmake
 
-#### Linux (Ubuntu)
+#### Linux (Ubuntu 16.04.2 LTS)
 
-    sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
-    sudo apt-get build-dep glfw
+    sudo apt install cmake libglew-dev xorg-dev libcurl4-openssl-dev
+    sudo apt install libglfw3-dev
 
 #### Windows
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,13 @@ dependencies:
         - mkdir native-build
         - cd native-build && cmake ..
         - sudo apt-get install emscripten
+        - mkdir release-build-js
+        - echo EMSCRIPTEN = $EMSCRIPTEN
+        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
 test:
     override:
         - cd native-build && make
+        - cd release-build-js && make
 general:
     artifacts:
         - "native-build/craft"

--- a/circle.yml
+++ b/circle.yml
@@ -6,10 +6,8 @@ dependencies:
     pre:
         - sudo apt-get install emscripten
         - emcc
-        - ls -lR /usr/share/emscripten/
-        - ls -lR /usr/share/emscripten/cmake
         - mkdir release-build-js
-        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
+        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Platform/Emscripten.cmake ..
         - sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
         - sudo apt-get install libglfw-dev
         - mkdir native-build

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ dependencies:
         - sudo apt-get install libglfw-dev
         - mkdir native-build
         - cd native-build && cmake ..
+        - sudo apt-get install emscripten
 test:
     override:
         - cd native-build && make

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,8 @@ dependencies:
     pre:
         - sudo apt-get install emscripten
         - emcc
-        - which emcc
+        - ls -l /usr/share/emscripten/cmake/Modules/Platform/Emscripten.cmake
+        - ls -l /usr/share/emscripten/
         - mkdir release-build-js
         - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
         - sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev

--- a/circle.yml
+++ b/circle.yml
@@ -4,13 +4,13 @@ machine:
 
 dependencies:
     pre:
+        - sudo apt-get install emscripten
+        - mkdir release-build-js
+        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
         - sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
         - sudo apt-get install libglfw-dev
         - mkdir native-build
         - cd native-build && cmake ..
-        - sudo apt-get install emscripten
-        - mkdir release-build-js
-        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
 test:
     override:
         - cd native-build && make

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ dependencies:
         - sudo apt-get install emscripten
         - emcc
         - ls -lR /usr/share/emscripten/
+        - ls -lR /usr/share/emscripten/cmake
         - mkdir release-build-js
         - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
         - sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,7 @@ dependencies:
     pre:
         - sudo apt-get install emscripten
         - emcc
-        - ls -l /usr/share/emscripten/cmake/Modules/Platform/Emscripten.cmake
-        - ls -l /usr/share/emscripten/
+        - ls -lR /usr/share/emscripten/
         - mkdir release-build-js
         - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
         - sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev

--- a/circle.yml
+++ b/circle.yml
@@ -1,20 +1,12 @@
-machine:
-    environment:
-        EMSCRIPTEN: /usr/share/emscripten
-
 dependencies:
     pre:
         - sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
         - sudo apt-get install libglfw-dev
         - mkdir native-build
         - cd native-build && cmake ..
-        - sudo apt-get install emscripten
-        - mkdir release-build-js
-        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Platform/Emscripten.cmake ..
 test:
     override:
         - cd native-build && make
-        - cd release-build-js && make
 general:
     artifacts:
         - "native-build/craft"

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@ machine:
 dependencies:
     pre:
         - sudo apt-get install emscripten
+        - emcc
+        - which emcc
         - mkdir release-build-js
         - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
         - sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+    environment:
+        EMSCRIPTEN: /usr/share/emscripten
+
 dependencies:
     pre:
         - sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
@@ -6,7 +10,7 @@ dependencies:
         - cd native-build && cmake ..
         - sudo apt-get install emscripten
         - mkdir release-build-js
-        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=/usr/share/emscripten/cmake/Modules/Platform/Emscripten.cmake ..
+        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
 test:
     override:
         - cd native-build && make

--- a/circle.yml
+++ b/circle.yml
@@ -4,14 +4,13 @@ machine:
 
 dependencies:
     pre:
-        - sudo apt-get install emscripten
-        - emcc
-        - mkdir release-build-js
-        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Platform/Emscripten.cmake ..
         - sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
         - sudo apt-get install libglfw-dev
         - mkdir native-build
         - cd native-build && cmake ..
+        - sudo apt-get install emscripten
+        - mkdir release-build-js
+        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Platform/Emscripten.cmake ..
 test:
     override:
         - cd native-build && make

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,7 @@ dependencies:
         - cd native-build && cmake ..
         - sudo apt-get install emscripten
         - mkdir release-build-js
-        - echo EMSCRIPTEN = $EMSCRIPTEN
-        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
+        - cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=/usr/share/emscripten/cmake/Modules/Platform/Emscripten.cmake ..
 test:
     override:
         - cd native-build && make


### PR DESCRIPTION
https://github.com/satoshinm/NetCraft/issues/37

(redoing since wasn't squashed: https://github.com/satoshinm/NetCraft/pull/71)