### PR TITLE
Remove hacks for emscripten issues, use patched emscripten

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,12 +31,25 @@ jobs:
                   (cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
                   mkdir wasm-build
                   (cd wasm-build && cmake -DWASM=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
+                  mkdir -p /tmp/artifacts/{release-build-js,wasm-build}
             - run:
                 name: native-build
                 command: cd native-build && make
             - run:
                 name: release-build-js
-                command: cd release-build-js && source ~/emsdk-portable/emsdk_env.sh && make
+                command: |
+                    cd release-build-js
+                    source ~/emsdk-portable/emsdk_env.sh
+                    make
+                    cp craft.* /tmp/artifacts/release-build-js
+            - store_artifacts:
+                path: /tmp/artifacts/release-build-js
             - run:
                 name: wasm-build
-                command: cd wasm-build && source ~/emsdk-portable/emsdk_env.sh && make
+                command: |
+                    cd wasm-build
+                    source ~/emsdk-portable/emsdk_env.sh
+                    make
+                    cp craft.* /tmp/artifacts/wasm-build
+            - store_artifacts:
+                path: /tmp/artifacts/wasm-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ jobs:
                   ~/emsdk-portable/emsdk install latest
                   ~/emsdk-portable/emsdk activate latest
                   source ~/emsdk-portable/emsdk_env.sh
+                  # fixes for https://github.com/satoshinm/emscripten/commits/netcraft
+                  curl -o ~/emscripten-fixes.patch 'https://gist.githubusercontent.com/satoshinm/1c5f517fd9cec6c0831302de9619a914/raw/93f3f67d008a57acd192709228f9fa5cdc4fe7db/emscripten-1.37.9+netcraftfixes.patch'
+                  (cd ~/emsdk-portable/emscripten/1.37.9 && patch -p1 < ~/emscripten-fixes.patch)
                   mkdir release-build-js
                   (cd release-build-js && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..)
                   mkdir wasm-build

--- a/README.md
+++ b/README.md
@@ -37,7 +37,15 @@ See below to run from source.
 
 ### Web builds
 
-To build for the web, compiling to JavaScript, install [Emscripten](http://emscripten.org) and run:
+To build for the web, compiling to JavaScript, first install [Emscripten](http://emscripten.org).
+The EM SDK is the easiest to install, but to get my patch fixes you can either build from source
+using this branch: https://github.com/satoshinm/emscripten/commits/netcraft, or alternatively
+install 1.37.9 from the SDK and apply a patch:
+
+    cd emsdk-portable/emscripten/1.37.9
+    curl 'https://gist.githubusercontent.com/satoshinm/1c5f517fd9cec6c0831302de9619a914/raw/93f3f67d008a57acd192709228f9fa5cdc4fe7db/emscripten-1.37.9+netcraftfixes.patch' | patch -p1
+
+Once you Emscripten environment is setup, then run:
 
     git clone https://github.com/satoshinm/NetCraft.git
     cd NetCraft

--- a/src/main.c
+++ b/src/main.c
@@ -2987,16 +2987,6 @@ static int g_running;
 static int g_inner_break;
 
 
-#ifdef __EMSCRIPTEN__
-EM_BOOL on_pointerlockchange(int eventType, const EmscriptenPointerlockChangeEvent *pointerlockChangeEvent, void *userData) {
-    if (!pointerlockChangeEvent->isActive) {
-        printf("pointerlockchange deactivated, so enabling cursor\n");
-        glfwSetInputMode(g->window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
-    }
-    return 0;
-}
-#endif
-
 int main(int argc, char **argv) {
     // INITIALIZATION //
 #ifndef __EMSCRIPTEN__
@@ -3016,11 +3006,7 @@ int main(int argc, char **argv) {
     }
 
     glfwMakeContextCurrent(g->window);
-#ifdef __EMSCRIPTEN__
-    emscripten_set_pointerlockchange_callback(NULL, NULL, 0, on_pointerlockchange);
-#else // web pointer lock requires user action to activate, start off disabled
     glfwSetInputMode(g->window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
-#endif
     glfwSetWindowSizeCallback(g->window, on_window_size);
     glfwSetKeyCallback(g->window, on_key);
     glfwSetCharCallback(g->window, on_char);

--- a/src/main.c
+++ b/src/main.c
@@ -2217,6 +2217,8 @@ void change_ortho_zoom(double ydelta) {
 }
 
 void fullscreen_toggle();
+static int touch_forward = 0;
+static int touch_jump = 0;
 void on_key(GLFWwindow *window, int key, int scancode, int action, int mods) {
     int control = mods & GLFW_MOD_CONTROL;
     int exclusive =
@@ -2239,7 +2241,7 @@ void on_key(GLFWwindow *window, int key, int scancode, int action, int mods) {
     if (action != GLFW_PRESS) {
         return;
     }
-    if (key == CRAFT_KEY_JUMP) {
+    if (key == CRAFT_KEY_JUMP || touch_jump) {
         static double last_jumped = 0;
         if (last_jumped != 0 && glfwGetTime() - last_jumped < JUMP_FLY_THRESHOLD) {
             g->flying = !g->flying;
@@ -2439,8 +2441,6 @@ void on_mouse_button(GLFWwindow *window, int button, int action, int mods) {
     }
 }
 
-static int touch_forward = 0;
-static int touch_jump = 0;
 #ifdef __EMSCRIPTEN__
 static long touch_active = 0;
 static double touch_activated_at = 0;
@@ -2738,39 +2738,6 @@ void handle_mouse_input() {
     }
 }
 
-// Partial workaround stuck keys in web, TODO: fix upstream in https://github.com/kripken/emscripten/issues/5122 and delete all this
-// When blurred, treat all keys as released. However, once the player refocuses
-// the game, then the keys will be stuck, again. Emscripten fix may be only possibility.
-// This is only for character keys, TODO: also for modifier keys like Command
-static int blurred = 0;
-int craftGetKey(GLFWwindow *window, int key) {
-    if (blurred) {
-        return GLFW_RELEASE;
-    }
-
-    if (touch_forward && key == CRAFT_KEY_FORWARD) {
-        return GLFW_PRESS;
-    }
-    if (touch_jump && key == CRAFT_KEY_JUMP) {
-        return GLFW_PRESS;
-    }
-
-    return glfwGetKey(window, key);
-}
-#ifdef __EMSCRIPTEN__
-EM_BOOL on_focus(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData) {
-   switch(eventType) {
-       case EMSCRIPTEN_EVENT_BLUR:
-           blurred = 1;
-           break;
-       case EMSCRIPTEN_EVENT_FOCUS:
-           blurred = 0;
-           break;
-   }
-   return EM_FALSE;
-}
-#endif
-
 void handle_movement(double dt) {
     static float dy = 0;
     State *s = &g->players->state;
@@ -2778,21 +2745,21 @@ void handle_movement(double dt) {
     int sx = 0;
     if (!g->typing) {
         float m = dt * 1.0;
-        g->ortho = craftGetKey(g->window, CRAFT_KEY_ORTHO) ? 64 : 0;
-        g->fov = craftGetKey(g->window, CRAFT_KEY_ZOOM) ? 15 : 65;
-        if (craftGetKey(g->window, CRAFT_KEY_FORWARD)) sz--;
-        if (craftGetKey(g->window, CRAFT_KEY_BACKWARD)) sz++;
-        if (craftGetKey(g->window, CRAFT_KEY_LEFT)) sx--;
-        if (craftGetKey(g->window, CRAFT_KEY_RIGHT)) sx++;
-        if (craftGetKey(g->window, GLFW_KEY_LEFT)) s->rx -= m;
-        if (craftGetKey(g->window, GLFW_KEY_RIGHT)) s->rx += m;
-        if (craftGetKey(g->window, GLFW_KEY_UP)) s->ry += m;
-        if (craftGetKey(g->window, GLFW_KEY_DOWN)) s->ry -= m;
+        g->ortho = glfwGetKey(g->window, CRAFT_KEY_ORTHO) ? 64 : 0;
+        g->fov = glfwGetKey(g->window, CRAFT_KEY_ZOOM) ? 15 : 65;
+        if (glfwGetKey(g->window, CRAFT_KEY_FORWARD) || touch_forward) sz--;
+        if (glfwGetKey(g->window, CRAFT_KEY_BACKWARD)) sz++;
+        if (glfwGetKey(g->window, CRAFT_KEY_LEFT)) sx--;
+        if (glfwGetKey(g->window, CRAFT_KEY_RIGHT)) sx++;
+        if (glfwGetKey(g->window, GLFW_KEY_LEFT)) s->rx -= m;
+        if (glfwGetKey(g->window, GLFW_KEY_RIGHT)) s->rx += m;
+        if (glfwGetKey(g->window, GLFW_KEY_UP)) s->ry += m;
+        if (glfwGetKey(g->window, GLFW_KEY_DOWN)) s->ry -= m;
     }
     float vx, vy = 0, vz;
     get_motion_vector(g->flying, sz, sx, s->rx, s->ry, &vx, &vy, &vz);
     if (!g->typing) {
-        if (craftGetKey(g->window, CRAFT_KEY_JUMP)) {
+        if (glfwGetKey(g->window, CRAFT_KEY_JUMP) || touch_jump) {
             if (g->flying) {
                 vy++;
             }
@@ -2800,7 +2767,7 @@ void handle_movement(double dt) {
                 dy = 8;
             }
         }
-        if (craftGetKey(g->window, CRAFT_KEY_CROUCH)) {
+        if (glfwGetKey(g->window, CRAFT_KEY_CROUCH)) {
             if (g->flying) {
                 int exclusive = glfwGetInputMode(g->window, GLFW_CURSOR)
                     == GLFW_CURSOR_DISABLED;
@@ -2811,8 +2778,8 @@ void handle_movement(double dt) {
         }
     }
     float speed = g->flying ? 20 : 5;
-    if (craftGetKey(g->window, CRAFT_KEY_SPRINT)) speed *= 2;
-    if (craftGetKey(g->window, CRAFT_KEY_CROUCH) && !g->flying) speed /= 2;
+    if (glfwGetKey(g->window, CRAFT_KEY_SPRINT)) speed *= 2;
+    if (glfwGetKey(g->window, CRAFT_KEY_CROUCH) && !g->flying) speed /= 2;
     int estimate = roundf(sqrtf(
         powf(vx * speed, 2) +
         powf(vy * speed + ABS(dy) * 2, 2) +
@@ -3135,8 +3102,6 @@ int main(int argc, char **argv) {
     // OUTER LOOP //
     g_running = 1;
 #ifdef __EMSCRIPTEN__
-    emscripten_set_blur_callback(NULL, NULL, EM_TRUE, on_focus);
-    emscripten_set_focus_callback(NULL, NULL, EM_TRUE, on_focus);
     emscripten_push_main_loop_blocker(main_init, NULL); // run before main loop
     emscripten_set_main_loop(one_iter, 0, 1);
     //main_shutdown(); // called in one_iter() if g_inner_break

--- a/src/main.c
+++ b/src/main.c
@@ -2217,10 +2217,8 @@ void change_ortho_zoom(double ydelta) {
 }
 
 void fullscreen_toggle();
-static int super_down = 0;
 void on_key(GLFWwindow *window, int key, int scancode, int action, int mods) {
     int control = mods & GLFW_MOD_CONTROL;
-    super_down = mods & GLFW_MOD_SUPER;
     int exclusive =
         glfwGetInputMode(window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED;
     if (action == GLFW_RELEASE) {
@@ -2344,11 +2342,6 @@ void on_key(GLFWwindow *window, int key, int scancode, int action, int mods) {
 }
 
 void on_char(GLFWwindow *window, unsigned int u) {
-    if (super_down) {
-        // TODO: why does emscripten call on_char if control is down? Cmd-` -> `
-        printf("on_char ignoring u=%d since control_down\n", u);
-        return;
-    }
     if (g->suppress_char) {
         g->suppress_char = 0;
         return;


### PR DESCRIPTION
Removes the partial hacks for some issues encountered with emscripten documented at https://github.com/satoshinm/emglfwbugs (all except fullscreen_fullwindow_toggle, that workaround is less impactful and will have to stay until someone can figure it out), now that I have developed working fixes in emscripten in my branch at: https://github.com/satoshinm/emscripten/tree/netcraft

Before merging, need to: update readme describing to use this emscripten branch, and most importantly, update the CircleCI configuration to pick up these fixes, too (fortunately, shouldn't be too difficult since it is all in the JavaScript source - patch the emsdk? no need to recompile llvm, clang, etc. from source)