### PR TITLE
Hit test cube face number for mining target and info text

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -450,9 +450,15 @@ void db_load_signs(SignList *list, int p, int q) {
         int y = sqlite3_column_int(load_signs_stmt, 1);
         int z = sqlite3_column_int(load_signs_stmt, 2);
         int face = sqlite3_column_int(load_signs_stmt, 3);
+        int rotation = 0;
+        if (face >= 4) {
+            // 4-8 encodes 90 degree rotation multiple on top face
+            rotation = face - 4;
+            face = 4;
+        }
         const char *text = (const char *)sqlite3_column_text(
             load_signs_stmt, 4);
-        sign_list_add(list, x, y, z, face, text);
+        sign_list_add(list, x, y, z, face, rotation, text);
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -685,7 +685,7 @@ int hit_test(
 int hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
     State *s = &player->state;
     int w = hit_test(false, s->x, s->y, s->z, s->rx, s->ry, x, y, z);
-    if (1||is_obstacle(w)) {
+    if (is_obstacle(w)) {
         int hx, hy, hz;
         hit_test(true, s->x, s->y, s->z, s->rx, s->ry, &hx, &hy, &hz);
         int dx = hx - *x;

--- a/src/main.c
+++ b/src/main.c
@@ -2178,14 +2178,13 @@ void on_light() {
     }
 }
 
-int get_targeted_block(int *hx, int *hy, int *hz) {
-    State *s = &g->players->state;
-    return hit_test(false, s->x, s->y, s->z, s->rx, s->ry, hx, hy, hz);
+int get_targeted_block(int *hx, int *hy, int *hz, int *face) {
+    return hit_test_face(g->players, hx, hy, hz, face);
 }
 
 void on_mine() {
-    int hx, hy, hz;
-    int hw = get_targeted_block(&hx, &hy, &hz);
+    int hx, hy, hz, face;
+    int hw = get_targeted_block(&hx, &hy, &hz, &face);
     if (hy > 0 && hy < 256 && is_destructable(hw)) {
         set_block(hx, hy, hz, 0);
         record_block(hx, hy, hz, 0);
@@ -3187,12 +3186,11 @@ void render_scene() {
                 hour = hour ? hour : 12;
 
                 // Targeted block information
-                // TODO: also show face (hit_target_face? but note return type)
-                int hx, hy, hz, hw;
-                hw = mining_get_target(&hx, &hy, &hz);
+                int hx, hy, hz, hw, face;
+                hw = mining_get_target(&hx, &hy, &hz, &face);
                 char block_info[256] = {0};
                 if (hw) snprintf(block_info, 256,
-                        "{%d, %d, %d} #%d %s", hx, hy, hz, hw, item_names[hw]);
+                        "{%d, %d, %d, %d} #%d %s", hx, hy, hz, face, hw, item_names[hw]);
 
                 snprintf(
                     text_buffer, 1024,

--- a/src/main.c
+++ b/src/main.c
@@ -682,7 +682,7 @@ int hit_test(
     return result;
 }
 
-int hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
+bool hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
     State *s = &player->state;
     int w = hit_test(false, s->x, s->y, s->z, s->rx, s->ry, x, y, z);
     if (is_obstacle(w)) {
@@ -692,16 +692,16 @@ int hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
         int dy = hy - *y;
         int dz = hz - *z;
         if (dx == -1 && dy == 0 && dz == 0) {
-            *face = 0; return w;
+            *face = 0; return true;
         }
         if (dx == 1 && dy == 0 && dz == 0) {
-            *face = 1; return w;
+            *face = 1; return true;
         }
         if (dx == 0 && dy == 0 && dz == -1) {
-            *face = 2; return w;
+            *face = 2; return true;
         }
         if (dx == 0 && dy == 0 && dz == 1) {
-            *face = 3; return w;
+            *face = 3; return true;
         }
         if (dx == 0 && dy == 1 && dz == 0) {
             int degrees = roundf(DEGREES(atan2f(s->x - hx, s->z - hz)));
@@ -709,10 +709,10 @@ int hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
                 degrees += 360;
             }
             int top = ((degrees + 45) / 90) % 4;
-            *face = 4 + top; return w;
+            *face = 4 + top; return true;
         }
     }
-    return 0;
+    return false;
 }
 
 bool collide(int height, float *x, float *y, float *z) {

--- a/src/main.c
+++ b/src/main.c
@@ -711,6 +711,15 @@ int hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
             int top = ((degrees + 45) / 90) % 4;
             *face = 4 + top; return w;
         }
+        if (dx == 0 && dy == -1 && dz == 0) {
+            int degrees = roundf(DEGREES(atan2f(s->x - hx, s->z - hz)));
+            if (degrees < 0) {
+                degrees += 360;
+            }
+            int top = ((degrees + 45) / 90) % 4;
+            *face = 4 + top; return w;
+        }
+
     }
     return 0;
 }
@@ -775,12 +784,12 @@ bool player_intersects_block(
 int _gen_sign_buffer(
     GLfloat *data, float x, float y, float z, int face, const char *text)
 {
-    static const int glyph_dx[8] = {0, 0, -1, 1, 1, 0, -1, 0};
-    static const int glyph_dz[8] = {1, -1, 0, 0, 0, -1, 0, 1};
-    static const int line_dx[8] = {0, 0, 0, 0, 0, 1, 0, -1};
-    static const int line_dy[8] = {-1, -1, -1, -1, 0, 0, 0, 0};
-    static const int line_dz[8] = {0, 0, 0, 0, 1, 0, -1, 0};
-    if (face < 0 || face >= 8) {
+    static const int glyph_dx[12] = {0, 0, -1, 1, 1, 0, -1, 0, 1, 0, -1, 0};
+    static const int glyph_dz[12] = {1, -1, 0, 0, 0, -1, 0, 1, 0, -1, 0, 1};
+    static const int line_dx[12] = {0, 0, 0, 0, 0, 1, 0, -1, 0, 1, 0, -1};
+    static const int line_dy[12] = {-1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0};
+    static const int line_dz[12] = {0, 0, 0, 0, 1, 0, -1, 0, 1, 0, -1, 0};
+    if (face < 0 || face >= 12) {
         return 0;
     }
     int count = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -682,7 +682,7 @@ int hit_test(
     return result;
 }
 
-bool hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
+int hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
     State *s = &player->state;
     int w = hit_test(false, s->x, s->y, s->z, s->rx, s->ry, x, y, z);
     if (is_obstacle(w)) {
@@ -692,16 +692,16 @@ bool hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
         int dy = hy - *y;
         int dz = hz - *z;
         if (dx == -1 && dy == 0 && dz == 0) {
-            *face = 0; return true;
+            *face = 0; return w;
         }
         if (dx == 1 && dy == 0 && dz == 0) {
-            *face = 1; return true;
+            *face = 1; return w;
         }
         if (dx == 0 && dy == 0 && dz == -1) {
-            *face = 2; return true;
+            *face = 2; return w;
         }
         if (dx == 0 && dy == 0 && dz == 1) {
-            *face = 3; return true;
+            *face = 3; return w;
         }
         if (dx == 0 && dy == 1 && dz == 0) {
             int degrees = roundf(DEGREES(atan2f(s->x - hx, s->z - hz)));
@@ -709,10 +709,10 @@ bool hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
                 degrees += 360;
             }
             int top = ((degrees + 45) / 90) % 4;
-            *face = 4 + top; return true;
+            *face = 4 + top; return w;
         }
     }
-    return false;
+    return 0;
 }
 
 bool collide(int height, float *x, float *y, float *z) {

--- a/src/main.c
+++ b/src/main.c
@@ -682,25 +682,17 @@ int hit_test(
     return result;
 }
 
-int hit_test_normal(Player *player, int *x, int *y, int *z, int *nx, int *ny, int *nz) {
+int hit_test_face(Player *player, int *x, int *y, int *z, int *face, int *nx, int *ny, int *nz) {
     State *s = &player->state;
+    int dx, dy, dz;
     int w = hit_test(false, s->x, s->y, s->z, s->rx, s->ry, x, y, z);
     if (!w) return 0;
 
     int hx, hy, hz;
     hit_test(true, s->x, s->y, s->z, s->rx, s->ry, &hx, &hy, &hz);
-    *nx = hx - *x;
-    *ny = hy - *y;
-    *nz = hz - *z;
-
-    return w;
-}
-
-int hit_test_face(Player *player, int *x, int *y, int *z, int *face, int *nx, int *ny, int *nz) {
-    State *s = &player->state;
-    int dx, dy, dz;
-    int w = hit_test_normal(g->players, x, y, z, &dx, &dy, &dz);
-    if (!w) return 0;
+    dx = hx - *x;
+    dy = hy - *y;
+    dz = hz - *z;
 
     if (nx) *nx = dx;
     if (ny) *ny = dy;

--- a/src/main.c
+++ b/src/main.c
@@ -685,7 +685,7 @@ int hit_test(
 int hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
     State *s = &player->state;
     int w = hit_test(false, s->x, s->y, s->z, s->rx, s->ry, x, y, z);
-    if (is_obstacle(w)) {
+    if (1||is_obstacle(w)) {
         int hx, hy, hz;
         hit_test(true, s->x, s->y, s->z, s->rx, s->ry, &hx, &hy, &hz);
         int dx = hx - *x;

--- a/src/main.c
+++ b/src/main.c
@@ -698,13 +698,9 @@ int hit_test_normal(Player *player, int *x, int *y, int *z, int *nx, int *ny, in
 
 bool hit_test_face_rotation(Player *player, int *x, int *y, int *z, int *face, int *rotation) {
     State *s = &player->state;
-    int w = hit_test(false, s->x, s->y, s->z, s->rx, s->ry, x, y, z);
+    int dx, dy, dz;
+    int w = hit_test_normal(g->players, x, y, z, &dx, &dy, &dz);
     if (is_obstacle(w)) {
-        int hx, hy, hz;
-        hit_test(true, s->x, s->y, s->z, s->rx, s->ry, &hx, &hy, &hz);
-        int dx = hx - *x;
-        int dy = hy - *y;
-        int dz = hz - *z;
         *rotation = 0;
         if (dx == -1 && dy == 0 && dz == 0) {
             *face = 0; return true;
@@ -719,7 +715,7 @@ bool hit_test_face_rotation(Player *player, int *x, int *y, int *z, int *face, i
             *face = 3; return true;
         }
         if (dx == 0 && dy == 1 && dz == 0) {
-            int degrees = roundf(DEGREES(atan2f(s->x - hx, s->z - hz)));
+            int degrees = roundf(DEGREES(atan2f(s->x - dx - *x, s->z - dz - *z)));
             if (degrees < 0) {
                 degrees += 360;
             }

--- a/src/main.c
+++ b/src/main.c
@@ -690,30 +690,26 @@ int hit_test_face(Player *player, int *x, int *y, int *z, int *face, int *nx, in
 
     int hx, hy, hz;
     hit_test(true, s->x, s->y, s->z, s->rx, s->ry, &hx, &hy, &hz);
-    dx = hx - *x;
-    dy = hy - *y;
-    dz = hz - *z;
+    *nx = hx - *x;
+    *ny = hy - *y;
+    *nz = hz - *z;
 
-    if (nx) *nx = dx;
-    if (ny) *ny = dy;
-    if (nz) *nz = dz;
-
-    if (dx == -1 && dy == 0 && dz == 0) {
+    if (*nx == -1 && *ny == 0 && *nz == 0) {
         *face = 0; return w;
     }
-    if (dx == 1 && dy == 0 && dz == 0) {
+    if (*nx == 1 && *ny == 0 && *nz == 0) {
         *face = 1; return w;
     }
-    if (dx == 0 && dy == 0 && dz == -1) {
+    if (*nx == 0 && *ny == 0 && *nz == -1) {
         *face = 2; return w;
     }
-    if (dx == 0 && dy == 0 && dz == 1) {
+    if (*nx == 0 && *ny == 0 && *nz == 1) {
         *face = 3; return w;
     }
-    if (dx == 0 && dy == 1 && dz == 0) {
+    if (*nx == 0 && *ny == 1 && *nz == 0) {
         *face = 4; return w;
     }
-    if (dx == 0 && dy == -1 && dz == 0) {
+    if (*nx == 0 && *ny == -1 && *nz == 0) {
         *face = 5; return w;
     }
 
@@ -725,6 +721,7 @@ bool hit_test_face_rotation(Player *player, int *x, int *y, int *z, int *face, i
     int dx, dy, dz;
     int w = hit_test_face(player, x, y, z, face, &dx, &dy, &dz);
 
+    // Only allowed to write signs on solid obstacle blocks
     if (is_obstacle(w)) {
         if (*face == 4 || *face == 5) {
             // Sign text on top (or bottom) should be rotated to face towards player writing it
@@ -2207,7 +2204,8 @@ void on_light() {
 }
 
 int get_targeted_block(int *x, int *y, int *z, int *face) {
-    return hit_test_face(g->players, x, y, z, face, NULL, NULL, NULL);
+    int nx, ny, nz;
+    return hit_test_face(g->players, x, y, z, face, &nx, &ny, &nz);
 }
 
 void on_mine() {

--- a/src/main.c
+++ b/src/main.c
@@ -696,36 +696,55 @@ int hit_test_normal(Player *player, int *x, int *y, int *z, int *nx, int *ny, in
     return w;
 }
 
-bool hit_test_face_rotation(Player *player, int *x, int *y, int *z, int *face, int *rotation) {
+int hit_test_face(Player *player, int *x, int *y, int *z, int *face, int *nx, int *ny, int *nz) {
     State *s = &player->state;
     int dx, dy, dz;
     int w = hit_test_normal(g->players, x, y, z, &dx, &dy, &dz);
-    if (is_obstacle(w)) {
-        *rotation = 0;
-        if (dx == -1 && dy == 0 && dz == 0) {
-            *face = 0; return true;
-        }
-        if (dx == 1 && dy == 0 && dz == 0) {
-            *face = 1; return true;
-        }
-        if (dx == 0 && dy == 0 && dz == -1) {
-            *face = 2; return true;
-        }
-        if (dx == 0 && dy == 0 && dz == 1) {
-            *face = 3; return true;
-        }
-        if (dx == 0 && dz == 0) {
-            if (dy == 1) *face = 4;
-            else if (dy == -1) *face = 5;
-            else return false;
+    if (!w) return 0;
 
+    if (nx) *nx = dx;
+    if (ny) *ny = dy;
+    if (nz) *nz = dz;
+
+    if (dx == -1 && dy == 0 && dz == 0) {
+        *face = 0; return w;
+    }
+    if (dx == 1 && dy == 0 && dz == 0) {
+        *face = 1; return w;
+    }
+    if (dx == 0 && dy == 0 && dz == -1) {
+        *face = 2; return w;
+    }
+    if (dx == 0 && dy == 0 && dz == 1) {
+        *face = 3; return w;
+    }
+    if (dx == 0 && dy == 1 && dz == 0) {
+        *face = 4; return w;
+    }
+    if (dx == 0 && dy == -1 && dz == 0) {
+        *face = 5; return w;
+    }
+
+    return 0;
+}
+
+bool hit_test_face_rotation(Player *player, int *x, int *y, int *z, int *face, int *rotation) {
+    State *s = &player->state;
+    int dx, dy, dz;
+    int w = hit_test_face(player, x, y, z, face, &dx, &dy, &dz);
+
+    if (is_obstacle(w)) {
+        if (*face == 4 || *face == 5) {
+            // Sign text on top (or bottom) should be rotated to face towards player writing it
             int degrees = roundf(DEGREES(atan2f(s->x - dx - *x, s->z - dz - *z)));
             if (degrees < 0) {
                 degrees += 360;
             }
             *rotation = ((degrees + 45) / 90) % 4;
-            return true;
+        } else {
+            *rotation = 0;
         }
+        return true;
     }
     return false;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2214,13 +2214,13 @@ void on_light() {
     }
 }
 
-int get_targeted_block(int *x, int *y, int *z, int *nx, int *ny, int *nz) {
-    return hit_test_normal(g->players, x, y, z, nx, ny, nz);
+int get_targeted_block(int *x, int *y, int *z, int *face) {
+    return hit_test_face(g->players, x, y, z, face, NULL, NULL, NULL);
 }
 
 void on_mine() {
-    int hx, hy, hz, nx, ny, nz;
-    int hw = get_targeted_block(&hx, &hy, &hz, &nx, &ny, &nz);
+    int hx, hy, hz, face;
+    int hw = get_targeted_block(&hx, &hy, &hz, &face);
     if (hy > 0 && hy < 256 && is_destructable(hw)) {
         set_block(hx, hy, hz, 0);
         record_block(hx, hy, hz, 0);
@@ -3228,14 +3228,12 @@ void render_scene() {
                 hour = hour ? hour : 12;
 
                 // Targeted block information
-                int hx, hy, hz, hw, nx, ny, nz;
-                hw = mining_get_target(&hx, &hy, &hz, &nx, &ny, &nz);
+                int hx, hy, hz, hw, face;
+                hw = mining_get_target(&hx, &hy, &hz, &face);
                 char block_info[256] = {0};
                 if (hw) snprintf(block_info, 256,
-                        "{%d, %d, %d} %c%c%c #%d %s", hx, hy, hz,
-                        nx ? (nx > 0 ? '+' : '-') : '0',
-                        ny ? (ny > 0 ? '+' : '-') : '0',
-                        nz ? (nz > 0 ? '+' : '-') : '0',
+                        "{%d, %d, %d, %d} #%d %s", hx, hy, hz,
+                        face,
                         hw, item_names[hw]);
 
                 snprintf(

--- a/src/main.c
+++ b/src/main.c
@@ -711,15 +711,6 @@ int hit_test_face(Player *player, int *x, int *y, int *z, int *face) {
             int top = ((degrees + 45) / 90) % 4;
             *face = 4 + top; return w;
         }
-        if (dx == 0 && dy == -1 && dz == 0) {
-            int degrees = roundf(DEGREES(atan2f(s->x - hx, s->z - hz)));
-            if (degrees < 0) {
-                degrees += 360;
-            }
-            int top = ((degrees + 45) / 90) % 4;
-            *face = 4 + top; return w;
-        }
-
     }
     return 0;
 }
@@ -784,12 +775,12 @@ bool player_intersects_block(
 int _gen_sign_buffer(
     GLfloat *data, float x, float y, float z, int face, const char *text)
 {
-    static const int glyph_dx[12] = {0, 0, -1, 1, 1, 0, -1, 0, 1, 0, -1, 0};
-    static const int glyph_dz[12] = {1, -1, 0, 0, 0, -1, 0, 1, 0, -1, 0, 1};
-    static const int line_dx[12] = {0, 0, 0, 0, 0, 1, 0, -1, 0, 1, 0, -1};
-    static const int line_dy[12] = {-1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0};
-    static const int line_dz[12] = {0, 0, 0, 0, 1, 0, -1, 0, 1, 0, -1, 0};
-    if (face < 0 || face >= 12) {
+    static const int glyph_dx[8] = {0, 0, -1, 1, 1, 0, -1, 0};
+    static const int glyph_dz[8] = {1, -1, 0, 0, 0, -1, 0, 1};
+    static const int line_dx[8] = {0, 0, 0, 0, 0, 1, 0, -1};
+    static const int line_dy[8] = {-1, -1, -1, -1, 0, 0, 0, 0};
+    static const int line_dz[8] = {0, 0, 0, 0, 1, 0, -1, 0};
+    if (face < 0 || face >= 8) {
         return 0;
     }
     int count = 0;

--- a/src/mining.c
+++ b/src/mining.c
@@ -10,21 +10,24 @@ static bool holding_build_button = false;
 static int mining_x = 0;
 static int mining_y = 0;
 static int mining_z = 0;
+static int mining_face = 0;
 
 static int target_x = 0;
 static int target_y = 0;
 static int target_z = 0;
+static int target_face = 0;
 static int target_w = 0;
 
 extern void on_mine();
 extern void on_build();
-extern int get_targeted_block(int *hx, int *hy, int *hz);
+extern int get_targeted_block(int *hx, int *hy, int *hz, int *face);
 
 // Get cached mining target (fast)
-int mining_get_target(int *hx, int *hy, int *hz) {
+int mining_get_target(int *hx, int *hy, int *hz, int *face) {
     *hx = target_x;
     *hy = target_y;
     *hz = target_z;
+    *face = target_face;
     return target_w;
 }
 
@@ -35,7 +38,7 @@ void mining_stop() {
 
 void mining_tick() {
     // Retarget block every tick
-    target_w = get_targeted_block(&target_x, &target_y, &target_z);
+    target_w = get_targeted_block(&target_x, &target_y, &target_z, &target_face);
 
     if (holding_mine_button) {
         if (target_x != mining_x || target_y != mining_y || target_z != mining_z) {
@@ -61,7 +64,7 @@ void mining_tick() {
 void mining_start() {
     holding_mine_button = true;
 
-    (void) get_targeted_block(&mining_x, &mining_y, &mining_z);
+    (void) get_targeted_block(&mining_x, &mining_y, &mining_z, &mining_face);
 }
 
 

--- a/src/mining.c
+++ b/src/mining.c
@@ -14,23 +14,19 @@ static int mining_z = 0;
 static int target_x = 0;
 static int target_y = 0;
 static int target_z = 0;
-static int normal_x = 0;
-static int normal_y = 0;
-static int normal_z = 0;
+static int target_face = 0;
 static int target_w = 0;
 
 extern void on_mine();
 extern void on_build();
-extern int get_targeted_block(int *x, int *y, int *z, int *nx, int *ny, int *nz);
+extern int get_targeted_block(int *x, int *y, int *z, int *face);
 
 // Get cached mining target (fast)
-int mining_get_target(int *x, int *y, int *z, int *nx, int *ny, int *nz) {
+int mining_get_target(int *x, int *y, int *z, int *face) {
     *x = target_x;
     *y = target_y;
     *z = target_z;
-    *nx = normal_x;
-    *ny = normal_y;
-    *nz = normal_z;
+    *face = target_face;
     return target_w;
 }
 
@@ -41,7 +37,7 @@ void mining_stop() {
 
 void mining_tick() {
     // Retarget block every tick
-    target_w = get_targeted_block(&target_x, &target_y, &target_z, &normal_x, &normal_y, &normal_z);
+    target_w = get_targeted_block(&target_x, &target_y, &target_z, &target_face);
 
     if (holding_mine_button) {
         if (target_x != mining_x || target_y != mining_y || target_z != mining_z) {
@@ -67,7 +63,7 @@ void mining_tick() {
 void mining_start() {
     holding_mine_button = true;
 
-    (void) get_targeted_block(&mining_x, &mining_y, &mining_z, &normal_x, &normal_y, &normal_z);
+    (void) get_targeted_block(&mining_x, &mining_y, &mining_z, &target_face);
 }
 
 

--- a/src/mining.c
+++ b/src/mining.c
@@ -10,24 +10,27 @@ static bool holding_build_button = false;
 static int mining_x = 0;
 static int mining_y = 0;
 static int mining_z = 0;
-static int mining_face = 0;
 
 static int target_x = 0;
 static int target_y = 0;
 static int target_z = 0;
-static int target_face = 0;
+static int normal_x = 0;
+static int normal_y = 0;
+static int normal_z = 0;
 static int target_w = 0;
 
 extern void on_mine();
 extern void on_build();
-extern int get_targeted_block(int *hx, int *hy, int *hz, int *face);
+extern int get_targeted_block(int *x, int *y, int *z, int *nx, int *ny, int *nz);
 
 // Get cached mining target (fast)
-int mining_get_target(int *hx, int *hy, int *hz, int *face) {
-    *hx = target_x;
-    *hy = target_y;
-    *hz = target_z;
-    *face = target_face;
+int mining_get_target(int *x, int *y, int *z, int *nx, int *ny, int *nz) {
+    *x = target_x;
+    *y = target_y;
+    *z = target_z;
+    *nx = normal_x;
+    *ny = normal_y;
+    *nz = normal_z;
     return target_w;
 }
 
@@ -38,7 +41,7 @@ void mining_stop() {
 
 void mining_tick() {
     // Retarget block every tick
-    target_w = get_targeted_block(&target_x, &target_y, &target_z, &target_face);
+    target_w = get_targeted_block(&target_x, &target_y, &target_z, &normal_x, &normal_y, &normal_z);
 
     if (holding_mine_button) {
         if (target_x != mining_x || target_y != mining_y || target_z != mining_z) {
@@ -64,7 +67,7 @@ void mining_tick() {
 void mining_start() {
     holding_mine_button = true;
 
-    (void) get_targeted_block(&mining_x, &mining_y, &mining_z, &mining_face);
+    (void) get_targeted_block(&mining_x, &mining_y, &mining_z, &normal_x, &normal_y, &normal_z);
 }
 
 

--- a/src/mining.h
+++ b/src/mining.h
@@ -1,4 +1,4 @@
-int mining_get_target(int *hx, int *hy, int *hz, int *face);
+int mining_get_target(int *x, int *y, int *z, int *nx, int *ny, int *nz);
 void mining_stop();
 void mining_tick();
 void mining_start();

--- a/src/mining.h
+++ b/src/mining.h
@@ -1,4 +1,4 @@
-int mining_get_target(int *hx, int *hy, int *hz);
+int mining_get_target(int *hx, int *hy, int *hz, int *face);
 void mining_stop();
 void mining_tick();
 void mining_start();

--- a/src/mining.h
+++ b/src/mining.h
@@ -1,4 +1,4 @@
-int mining_get_target(int *x, int *y, int *z, int *nx, int *ny, int *nz);
+int mining_get_target(int *x, int *y, int *z, int *face);
 void mining_stop();
 void mining_tick();
 void mining_start();

--- a/src/sign.c
+++ b/src/sign.c
@@ -32,7 +32,7 @@ void _sign_list_add(SignList *list, Sign *sign) {
 }
 
 void sign_list_add(
-    SignList *list, int x, int y, int z, int face, const char *text)
+    SignList *list, int x, int y, int z, int face, int rotation, const char *text)
 {
     sign_list_remove(list, x, y, z, face);
     Sign sign;
@@ -40,6 +40,7 @@ void sign_list_add(
     sign.y = y;
     sign.z = z;
     sign.face = face;
+    sign.rotation = rotation;
     strncpy(sign.text, text, MAX_SIGN_LENGTH);
     sign.text[MAX_SIGN_LENGTH - 1] = '\0';
     _sign_list_add(list, &sign);

--- a/src/sign.h
+++ b/src/sign.h
@@ -8,6 +8,7 @@ typedef struct {
     int y;
     int z;
     int face;
+    int rotation;
     char text[MAX_SIGN_LENGTH];
 } Sign;
 
@@ -21,7 +22,7 @@ void sign_list_alloc(SignList *list, int capacity);
 void sign_list_free(SignList *list);
 void sign_list_grow(SignList *list);
 void sign_list_add(
-    SignList *list, int x, int y, int z, int face, const char *text);
+    SignList *list, int x, int y, int z, int face, int rotation, const char *text);
 int sign_list_remove(SignList *list, int x, int y, int z, int face);
 int sign_list_remove_all(SignList *list, int x, int y, int z);
 


### PR DESCRIPTION
Get the face on which a block is being targeted, using `hit_test_face()`.

Cube faces numbers:

| # | face |
| --- | --- |
| 0 | front |
| 1 | back |
| 2 | left |
| 3 | right |
| 4 | top |
| 5 | bottom |

---

~~Current problems:~~

* ~~hit_test_face() excludes non-obstacles, so can't mine plants~~
* ~~missing bottom face: 0,-1,0, can't mine from underneath a block~~, nor write on signs (intended by current design, writing on bottom of signs would be a new feature)