### PR TITLE
Optimize lodepng to use miniz, not its own zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ else ()
 endif ()
 
 add_definitions(-std=c99 -O3)
+add_definitions(-DLODEPNG_NO_COMPILE_ZLIB)
 
 if ($ENV{CIRCLECI})
     add_definitions(-DBUILD_NUM="$ENV{CIRCLE_BUILD_NUM}")

--- a/deps/lodepng/lodepng.c
+++ b/deps/lodepng/lodepng.c
@@ -2203,11 +2203,18 @@ static unsigned zlib_compress(unsigned char** out, size_t* outsize, const unsign
 #else /*no LODEPNG_COMPILE_ZLIB*/
 
 #ifdef LODEPNG_COMPILE_DECODER
+#include "miniz.h"
 static unsigned zlib_decompress(unsigned char** out, size_t* outsize, const unsigned char* in,
                                 size_t insize, const LodePNGDecompressSettings* settings)
 {
-  if (!settings->custom_zlib) return 87; /*no custom zlib function provided */
-  return settings->custom_zlib(out, outsize, in, insize, settings);
+  int rc = mz_uncompress(*out, (mz_ulong *)outsize, in, (mz_ulong)insize);
+  if (rc == Z_OK) return 0;
+  else {
+      printf("mz_uncompress failed: %d\n", rc);
+      return rc;
+  }
+  //if (!settings->custom_zlib) return 87; /*no custom zlib function provided */
+  //return settings->custom_zlib(out, outsize, in, insize, settings);
 }
 #endif /*LODEPNG_COMPILE_DECODER*/
 #ifdef LODEPNG_COMPILE_ENCODER


### PR DESCRIPTION
Reduce code duplication from https://github.com/satoshinm/NetCraft/pull/125 Add miniz 2.5.0, a zip file decompression library

|  | miniz+lodepng | lodepng using miniz | delta | KB
| --- | --- | --- | --- | -- |
| build | [317](https://circleci.com/gh/satoshinm/NetCraft/317#artifacts/containers/0) | 318
| release-build (craft.js) | 3902676 | 3893401 | -9275 bytes | 9 KB
| release-build (craft.html.mem) | 62992 | 62470 | -522 | 0.5 KB
| wasm-build (craft.js) | 1102409 | 1102409 | 0 | 0 KB
| wasm-build (craft.wasm) | 1453315 | 1448250 | -5065 | 5 KB
| native-build (NetCraft-Linux.tar.gz) | 2068480 | 2037760 | -30720 | 30 KB

total change for optimized asmjs: about -10 KB, webassembly: -5 KB. Gains back some of the cost from adding miniz, but not all (+57 KB and +29 KB). Before using miniz at all, to now using lodepng with miniz, +47 KB (optimized asmjs) and +24 KB (wasm).