### PR TITLE
Add support for downloading texture pack from server (t, command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,9 @@ See below to run from source.
 To build for the web, compiling to JavaScript, first install [Emscripten](http://emscripten.org).
 The EM SDK is the easiest to install, but to get my patch fixes you can either build from source
 using this branch: https://github.com/satoshinm/emscripten/commits/netcraft, or alternatively
-install 1.37.9 from the SDK and apply a patch:
+install 1.37.12 from the SDK and apply a patch:
 
-    patch -p1 -d $EMSCRIPTEN < src/emscripten-1.37.9+netcraftfixes.patch
-    cp deps/glfw/include/GLFW/glfw3.h $EMSCRIPTEN/system/include/GLFW/glfw3.h
+    patch -p1 -d $EMSCRIPTEN < src/emscripten-1.37.12+netcraftfixes.patch
 
 Once your Emscripten environment is setup, then run:
 
@@ -195,7 +194,7 @@ Mouse:
 - Ctrl + Right Click to toggle a block as a light source.
 - Middle Click to change the current block selection to the targeted block.
 - Scrollwheel to cycle through the block types, or zoom in orthogonal mode.
-- Drag-and-drop files onto the canvas to change the texture.png.
+- Drag-and-drop files onto the canvas to change [textures](#textures).
 
 Keyboard:
 
@@ -307,8 +306,21 @@ Text is rendered using a bitmap atlas. Each character is rendered onto two trian
 
 Transparency in glass blocks and plants (plants don’t take up the full rectangular shape of their triangle primitives) is implemented by discarding magenta-colored pixels in the fragment shader.
 
-Block textures are based on the Pixeludi Pack by Wojtek Mroczek, Creative Commons CC-BY-SA, 2011,
-as in [TrueCraft](https://github.com/SirCmpwn/TrueCraft/).
+#### Textures
+
+Textures are based on the Pixeludi Pack by Wojtek Mroczek, Creative Commons CC-BY-SA, 2011,
+as used in [TrueCraft](https://github.com/SirCmpwn/TrueCraft/).
+
+Custom textures can be loaded from the server, or by dragging-and-dropping a .zip file or .png texture atlas
+onto the game. NetCraft uses its own texture format, although there is some interoperability provided.
+To customize textures you can start with [/textures/texture.png](/textures/texture.png), or (may not work
+completely as expected), seek out an old texture pack for Minecraft 1.4.7 or earlier, such as
+[Pixeludi](https://github.com/SirCmpwn/TrueCraft/blob/7f0e3338d231b8a8f7fba35742b618a4fb3575bf/TrueCraft.Client/Content/terrain.png),
+[Piehole](http://piehole.alexvoelk.de), or
+[Sphax PureBDcraft 16x](http://bdcraft.net/purebdcraft-minecraft#older).
+Only texture atlas images are supported, in a manner somewhat compatible with [pre-1.5](http://minecraft.gamepedia.com/Texture_pack#Converting_texture_packs_to_resource_packs)
+packs. High-resolution texture packs and packs for 1.5+ or newer, including resource packs, are not supported!
+
 
 #### Database
 

--- a/src/util.c
+++ b/src/util.c
@@ -6,6 +6,7 @@
 #include "miniz.h"
 #include "matrix.h"
 #include "util.h"
+#include "miniz.h"
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
@@ -160,6 +161,35 @@ void load_main_texture(const char *path) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     load_png_texture(path);
+}
+
+void load_zipped_textures(const char *path) {
+    mz_zip_archive zip_archive;
+    mz_bool status = mz_zip_reader_init_file(&zip_archive, path, 0);
+    if (!status) {
+        printf("failed to init zip file: %s\n", path);
+        return;
+    }
+
+    printf("num files: %d\n", (int)mz_zip_reader_get_num_files(&zip_archive));
+
+    status = mz_zip_reader_extract_file_to_file(&zip_archive, "terrain.png", "/tmp/terrain.png", 0);
+    if (!status) {
+        printf("failed to extract terrain.png, is this a compatible texture pack? %s\n", path);
+        mz_zip_end(&zip_archive);
+        return;
+    }
+
+    printf("found terrain.png in zip, loading\n");
+    load_block_texture("/tmp/terrain.png");
+    // TODO: load other textures
+    // TODO: support "resource pack" format
+
+    mz_zip_end(&zip_archive);
+}
+
+void fail_load_texture(const char *path) {
+    printf("failed to load texture: %s\n", path);
 }
 
 // Load a 256x256 block texture into the lower-left corner of the main texture

--- a/src/util.h
+++ b/src/util.h
@@ -40,6 +40,8 @@ GLuint make_program(GLuint shader1, GLuint shader2);
 GLuint load_program(const char *path1, const char *path2);
 void load_png_texture(const char *file_name);
 void load_main_texture(const char *file_name);
+void load_zipped_textures(const char *file_name);
+void fail_load_texture(const char *file_name);
 void load_block_texture(const char *file_name);
 void load_font_texture(const char *file_name);
 void load_sky_texture(const char *file_name);


### PR DESCRIPTION
The new "t," command specifies a URL to download the .zip from to use as
textures, or "-" to use the current host + /textures.zip. It will be
downloaded and used as if it was dropped onto the game as a file.