### PR TITLE
Listen for devicemotion event

### DIFF
--- a/src/accel.c
+++ b/src/accel.c
@@ -7,7 +7,7 @@ void init_accel_callbacks(void) {
 #include <emscripten/html5.h>
 
 static EM_BOOL on_devicemotion(int eventtype, const EmscriptenDeviceMotionEvent *event, void *userData) {
-    printf("accel x=%g, y=%g, %g\n", event->accelerationX, event->accelerationY, event->accelerationZ);
+    //printf("accel x=%g, y=%g, %g\n", event->accelerationX, event->accelerationY, event->accelerationZ);
     // TODO: free look
 
     return EM_TRUE;

--- a/src/accel.c
+++ b/src/accel.c
@@ -1,0 +1,20 @@
+#ifndef __EMSCRIPTEN__
+void init_accel_callbacks(void) {
+}
+
+#else
+#include <emscripten.h>
+#include <emscripten/html5.h>
+
+static EM_BOOL on_devicemotion(int eventtype, const EmscriptenDeviceMotionEvent *event, void *userData) {
+    printf("accel x=%g, y=%g, %g\n", event->accelerationX, event->accelerationY, event->accelerationZ);
+    // TODO: free look
+
+    return EM_TRUE;
+}
+
+void init_accel_callbacks(void) {
+    emscripten_set_devicemotion_callback(NULL, EM_TRUE, on_devicemotion);
+}
+#endif
+

--- a/src/accel.h
+++ b/src/accel.h
@@ -1,0 +1,1 @@
+void init_accel_callbacks(void);

--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,7 @@
 #include "miniz.h"
 #include "gamemode.h"
 #include "inventory.h"
+#include "accel.h"
 
 #define MAX_CHUNKS 8192
 #define MAX_PLAYERS 128
@@ -3159,6 +3160,7 @@ int main(int argc, char **argv) {
     glfwSetScrollCallback(g->window, on_scroll);
     init_joystick_callbacks();
     init_touch_callbacks(g->window);
+    init_accel_callbacks();
     init_blocks();
 
 #ifdef __EMSCRIPTEN__


### PR DESCRIPTION
Allow device acceleration (`devicemotion` HTML5 event: http://kripken.github.io/emscripten-site/docs/api_reference/html5.h.html#device-motion) to move the camera freely, as an alternative to free look with the mouse or touch or keyboard or joystick.

This is important for e.g. Google Cardboard support