### PR TITLE
Fix unaligned memory load in client socket address. Closes GH-192

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -244,7 +244,11 @@ void client_connect(char *hostname, int port) {
     }
     memset(&address, 0, sizeof(address));
     address.sin_family = AF_INET;
-    address.sin_addr.s_addr = ((struct in_addr *)(host->h_addr_list[0]))->s_addr;
+
+    char **ip_addr;
+    memcpy(&ip_addr, &(host->h_addr_list[0]), sizeof(void *));
+    memcpy(&address.sin_addr.s_addr, ip_addr, sizeof(struct in_addr));
+
     address.sin_port = htons(port);
     if ((sd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
         perror("socket");


### PR DESCRIPTION
Native build, `/online localhost`, causes unaligned memory access warnings with -fsanitize=undefined:

```
Connecting to server localhost:4080...
/NetCraft/src/client.c:247:51: runtime error: load of misaligned address 0x60b000073aaa for type 'char *', which requires 8 byte alignment
0x60b000073aaa: note: pointer points here
 00 00  00 00 ba 3a 07 00 b0 60  00 00 00 00 00 00 00 00  00 00 7f 00 00 01 00 00  b9 96 6e cc 00 00
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /NetCraft/src/client.c:247:51 in 
/NetCraft/src/client.c:247:75: runtime error: member access within misaligned address 0x60b000073aba for type 'struct in_addr', which requires 4 byte alignment
0x60b000073aba: note: pointer points here
 00 00  00 00 7f 00 00 01 00 00  b9 96 6e cc 00 00 00 00  f0 3a 07 00 b0 60 00 00  00 00 00 00 00 00
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /NetCraft/src/client.c:247:75 in 
/NetCraft/src/client.c:247:75: runtime error: load of misaligned address 0x60b000073aba for type 'in_addr_t' (aka 'unsigned int'), which requires 4 byte alignment
0x60b000073aba: note: pointer points here
 00 00  00 00 7f 00 00 01 00 00  b9 96 6e cc 00 00 00 00  f0 3a 07 00 b0 60 00 00  00 00 00 00 00 00
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /NetCraft/src/client.c:247:75 in 
```

To fix use memcpy: https://stackoverflow.com/questions/18821491/how-to-fix-unaligned-pointer-char/44490912#44490912 